### PR TITLE
Fix kex methods

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -189,6 +189,10 @@
     "message": "Initialization of SSH2 session failed",
     "description": "libssh2_session_init() failed"
   },
+  "sftpThreadError_sshKEXMethodPrefsFailed" : {
+    "message": "Couldn't set key exchange method preferences",
+    "description": "libssh_session_method_prefs() failed"
+  },
   "sftpThreadError_sshSessionHandshakeFailed" : {
     "message": "Finishing SSH2 session failed",
     "description": "Error when starting up SSH session"

--- a/src/_locales/nl/messages.json
+++ b/src/_locales/nl/messages.json
@@ -185,6 +185,9 @@
   "sftpThreadError_sshInitSessionFailed" : {
     "message": "Initialiseren van een SSH2-sessie is mislukt"
   },
+  "sftpThreadError_sshKEXMethodPrefsFailed" : {
+    "message": "Kan de voorkeuren voor de sleuteluitwisseling methode niet instellen"
+  },
   "sftpThreaderror_sshSessionHandshakeFailed" : {
     "message": "Voltooien van een SSH2-sessie is mislukt"
   },

--- a/src/nacl_src/sftp_thread.h
+++ b/src/nacl_src/sftp_thread.h
@@ -71,6 +71,7 @@ class SftpThread
   void InitializeLibssh2() throw(CommunicationException);
   int ConnectToSshServer(const std::string &hostname, const int port) throw(CommunicationException);
   LIBSSH2_SESSION* InitializeSession() throw(CommunicationException);
+  void SetKEXMethodPrefs(LIBSSH2_SESSION *session) throw(CommunicationException);
   void HandshakeSession(LIBSSH2_SESSION *session,
                         int sock) throw(CommunicationException);
   std::string GetHostKeyHash(LIBSSH2_SESSION *session);


### PR DESCRIPTION
Quick change to specify the KEX mechanism, in case `diffie-hellman-group-exchange-sha256` works in the wild, or `libssh2` decides to add support for more mechanisms.